### PR TITLE
Fix the expression widget test

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3113,8 +3113,12 @@ bool QgsExpression::isValid( const QString &text, const QgsExpressionContext *co
 {
   QgsExpression exp( text );
   exp.prepare( context );
-  errorMessage = exp.parserErrorString();
-  return !exp.hasParserError();
+  if ( exp.hasParserError() )
+    errorMessage = exp.parserErrorString();
+  else if ( exp.hasEvalError() )
+    errorMessage = exp.evalErrorString();
+
+  return !exp.hasParserError() && !exp.hasEvalError();
 }
 
 void QgsExpression::setScale( double scale ) { d->mScale = scale; }

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -148,6 +148,8 @@ void QgsFieldExpressionWidget::setLayer( QgsMapLayer *layer )
 
 void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )
 {
+  disconnect( mFieldProxyModel->sourceFieldModel()->layer(), SIGNAL( updatedFields() ), this, SLOT( reloadLayer() ) );
+
   mExpressionContext.reset( new QgsExpressionContext() );
   mExpressionContext->appendScope( QgsExpressionContextUtils::globalScope() );
   mExpressionContext->appendScope( QgsExpressionContextUtils::projectScope() );
@@ -155,6 +157,8 @@ void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )
     mExpressionContext->appendScope( QgsExpressionContextUtils::layerScope( layer ) );
 
   mFieldProxyModel->sourceFieldModel()->setLayer( layer );
+
+  connect( mFieldProxyModel->sourceFieldModel()->layer(), SIGNAL( updatedFields() ), this, SLOT( reloadLayer() ) );
 }
 
 void QgsFieldExpressionWidget::setField( const QString &fieldName )
@@ -229,6 +233,11 @@ void QgsFieldExpressionWidget::changeEvent( QEvent* event )
   {
     updateLineEditStyle();
   }
+}
+
+void QgsFieldExpressionWidget::reloadLayer()
+{
+  setLayer( mFieldProxyModel->sourceFieldModel()->layer() );
 }
 
 void QgsFieldExpressionWidget::currentFieldChanged()

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -147,6 +147,9 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
   protected:
     void changeEvent( QEvent* event ) override;
 
+  private slots:
+    void reloadLayer();
+
   private:
     QComboBox* mCombo;
     QToolButton* mButton;


### PR DESCRIPTION
Please have a short look at it and create a pull request for @nyalldawson to review.

I changed the way `QgsExpression::isValid()` interprets expressions, in particular it's a bit less tolerant now and may break certaing things because of incomplete expression contexts. It may be necessary to add a flag to decide if eval errors should be reported as failures or more control over the expression context or even a  better feedback from prepare to differentiate between missing variables and missing fields.

It would be great to have Nyall's feedback.
