### PR TITLE
Add addPartWkbType and use it for QgsCurve addPart

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -902,6 +902,16 @@ Adds a new part to this geometry.
 :return: OperationResult a result code: success or reason of failure
 %End
 
+    Qgis::GeometryOperationResult addPartWkbType( QgsAbstractGeometry *part /Transfer/, Qgis::WkbType wkbType = Qgis::WkbType::Unknown );
+%Docstring
+Adds a new part to this geometry.
+
+:param part: part to add (ownership is transferred)
+:param wkbType: default WKB type to create if no existing geometry
+
+:return: OperationResult a result code: success or reason of failure
+%End
+
     Qgis::GeometryOperationResult addPart( const QgsGeometry &newPart ) /PyName=addPartGeometry/;
 %Docstring
 Adds a new island polygon to a multipolygon feature

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -902,6 +902,16 @@ Adds a new part to this geometry.
 :return: OperationResult a result code: success or reason of failure
 %End
 
+    Qgis::GeometryOperationResult addPartWkbType( QgsAbstractGeometry *part /Transfer/, Qgis::WkbType wkbType = Qgis::WkbType::Unknown );
+%Docstring
+Adds a new part to this geometry.
+
+:param part: part to add (ownership is transferred)
+:param wkbType: default WKB type to create if no existing geometry
+
+:return: OperationResult a result code: success or reason of failure
+%End
+
     Qgis::GeometryOperationResult addPart( const QgsGeometry &newPart ) /PyName=addPartGeometry/;
 %Docstring
 Adds a new island polygon to a multipolygon feature

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -935,6 +935,42 @@ Qgis::GeometryOperationResult QgsGeometry::addPart( const QgsPointSequence &poin
   return addPart( partGeom.release(), geomType );
 }
 
+Qgis::GeometryOperationResult QgsGeometry::addPartWkbType( QgsAbstractGeometry *part, Qgis::WkbType wkbType )
+{
+  std::unique_ptr< QgsAbstractGeometry > p( part );
+  if ( !d->geometry )
+  {
+    switch ( QgsWkbTypes::flatType( wkbType ) )
+    {
+      case Qgis::WkbType::Point:
+        reset( std::make_unique< QgsMultiPoint >() );
+        break;
+      case Qgis::WkbType::LineString:
+        reset( std::make_unique< QgsMultiLineString >() );
+        break;
+      case Qgis::WkbType::Polygon:
+        reset( std::make_unique< QgsMultiPolygon >() );
+        break;
+      case Qgis::WkbType::CurvePolygon:
+        reset( std::make_unique< QgsMultiSurface >() );
+        break;
+      case Qgis::WkbType::CompoundCurve:
+        reset( std::make_unique< QgsMultiCurve >() );
+        break;
+      default:
+        reset( nullptr );
+        return Qgis::GeometryOperationResult::AddPartNotMultiGeometry;
+    }
+  }
+  else
+  {
+    detach();
+  }
+
+  convertToMultiType();
+  return QgsGeometryEditUtils::addPart( d->geometry.get(), std::move( p ) );
+}
+
 Qgis::GeometryOperationResult QgsGeometry::addPart( QgsAbstractGeometry *part, Qgis::GeometryType geomType )
 {
   std::unique_ptr< QgsAbstractGeometry > p( part );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -944,6 +944,14 @@ class CORE_EXPORT QgsGeometry
     Qgis::GeometryOperationResult addPart( QgsAbstractGeometry *part SIP_TRANSFER, Qgis::GeometryType geomType = Qgis::GeometryType::Unknown );
 
     /**
+     * Adds a new part to this geometry.
+     * \param part part to add (ownership is transferred)
+     * \param wkbType default WKB type to create if no existing geometry
+     * \returns OperationResult a result code: success or reason of failure
+     */
+    Qgis::GeometryOperationResult addPartWkbType( QgsAbstractGeometry *part SIP_TRANSFER, Qgis::WkbType wkbType = Qgis::WkbType::Unknown );
+
+    /**
      * Adds a new island polygon to a multipolygon feature
      * \returns OperationResult a result code: success or reason of failure
      * \note available in python bindings as addPartGeometry

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -306,7 +306,7 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( QgsCurve *ring, 
     geometry = f.geometry();
   }
 
-  Qgis::GeometryOperationResult errorCode = geometry.addPart( ring, mLayer->geometryType() );
+  Qgis::GeometryOperationResult errorCode = geometry.addPartWkbType( ring, mLayer->wkbType() );
   if ( errorCode == Qgis::GeometryOperationResult::Success )
   {
     if ( firstPart && QgsWkbTypes::isSingleType( mLayer->wkbType() )


### PR DESCRIPTION
## Description

Here is a commit that fixes the test.

I will submit a dedicated PR on QGIS repo for master branch, that will aim to deprecate all addPart methods of QgsGeometry and create equivalents V2, using Qgis::WkbType instead of Qgis::GeometryType.